### PR TITLE
fix: error indicators in Dos card

### DIFF
--- a/src/components/pages/index/index.jsx
+++ b/src/components/pages/index/index.jsx
@@ -28,14 +28,9 @@ export default class Index extends React.Component {
 
 	render() {
 		return (
-			<div>
-				<div className={ styles.row }>
-					<AboutNginx className={ styles.box } />
-				</div>
-
-				<div className={ `${ styles.row } ${ styles['row-wrap'] }` }>
-					<ProtectedObjects />
-				</div>
+			<div className={ styles.row }>
+				<AboutNginx className={ styles.box } />
+				<ProtectedObjects />
 			</div>
 		);
 	}

--- a/src/components/pages/index/protectedobjects.jsx
+++ b/src/components/pages/index/protectedobjects.jsx
@@ -27,6 +27,7 @@ export class ProtectedObjects extends React.Component {
 				<AlertsCount
 					href="#protected_objects"
 					total={stats.total}
+					warnings={stats.warnings}
 					alerts={stats.alerts}
 				/>
 			</IndexBox>


### PR DESCRIPTION
If at list one Protected Object becomes orange/red, it will be reflected in the Dos card.
Warning (orange) will show a problem, Danger (red) will show an alert.